### PR TITLE
TAG 270 Legge til frontendlogger

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+# .prettierrc or .prettierrc.yaml
+trailingComma: "es5"
+tabWidth: 4
+semi: true
+singleQuote: true

--- a/public/index.html
+++ b/public/index.html
@@ -29,19 +29,15 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+
+    <script type="application/javascript">
+      window.frontendlogger = { info: function(){}, warn: function(){}, error: function(){}, event: function(){}};
+      window.frontendlogger.appname = 'kontakt-oss';
+    </script>
+    <script type="application/javascript" src="/frontendlogger/logger.js"></script>
+
     {{{NAV_HEADING}}}
     <div id="root"></div>
     {{{NAV_FOOTER}}}
-
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import App from './App';
 
 it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+    const div = document.createElement('div');
+    ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ class App extends React.Component {
       <div className="App">
         <h1>Kontaktskjema</h1>
         <button onClick={() => {
-            (window as any).frontendLogger.event('en.test.event');
+            (window as any).frontendlogger.event('en.test.event');
         }}>
             Logg til Grafana
         </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,11 @@
 import * as React from 'react';
 import './App.less';
-import { logError, logEvent } from './utils/metricsUtils';
 
 class App extends React.Component {
     render() {
         return (
             <div className="App">
                 <h1>Kontaktskjema</h1>
-                <button
-                    onClick={() => {
-                        logEvent('kontakt-oss.en.test.event');
-                    }}
-                >
-                    Logg event
-                </button>
-                <button
-                    onClick={() => {
-                        logError('En feil har skjedd.');
-                    }}
-                >
-                    Logg til Grafana
-                </button>
             </div>
         );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,11 @@ class App extends React.Component {
     return (
       <div className="App">
         <h1>Kontaktskjema</h1>
+        <button onClick={() => {
+            (window as any).frontendLogger.event('en.test.event');
+        }}>
+            Logg til Grafana
+        </button>
       </div>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,22 @@
 import * as React from 'react';
 import './App.less';
+import { log } from './utils/metricsUtils';
 
 class App extends React.Component {
-  render() {
-    return (
-      <div className="App">
-        <h1>Kontaktskjema</h1>
-        <button onClick={() => {
-            (window as any).frontendlogger.event('en.test.event');
-        }}>
-            Logg til Grafana
-        </button>
-      </div>
-    );
-  }
+    render() {
+        return (
+            <div className="App">
+                <h1>Kontaktskjema</h1>
+                <button
+                    onClick={() => {
+                        log('en.test.event');
+                    }}
+                >
+                    Logg til Grafana
+                </button>
+            </div>
+        );
+    }
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import './App.less';
-import { log } from './utils/metricsUtils';
+import { logError, logEvent } from './utils/metricsUtils';
 
 class App extends React.Component {
     render() {
@@ -9,7 +9,14 @@ class App extends React.Component {
                 <h1>Kontaktskjema</h1>
                 <button
                     onClick={() => {
-                        log('en.test.event');
+                        logEvent('kontakt-oss.en.test.event');
+                    }}
+                >
+                    Logg event
+                </button>
+                <button
+                    onClick={() => {
+                        logError('En feil har skjedd.');
                     }}
                 >
                     Logg til Grafana

--- a/src/server/basePath.js
+++ b/src/server/basePath.js
@@ -1,1 +1,1 @@
-module.exports = (subPath) => '/kontakt-oss' + subPath;
+module.exports = subPath => '/kontakt-oss' + subPath;

--- a/src/server/decorator.js
+++ b/src/server/decorator.js
@@ -2,23 +2,34 @@ const jsdom = require('jsdom');
 const request = require('request');
 
 const { JSDOM } = jsdom;
-const url = 'https://appres.nav.no/common-html/v4/navno?header-withmenu=true&styles=true&scripts=true&footer-withmenu=true';
+const url =
+    'https://appres.nav.no/common-html/v4/navno?header-withmenu=true&styles=true&scripts=true&footer-withmenu=true';
 
-const requestDecorator = (callback) => request(url, callback);
+const requestDecorator = callback => request(url, callback);
 
 const getDecorator = () =>
     new Promise((resolve, reject) => {
         const callback = (error, response, body) => {
-            if (!error && response.statusCode >= 200 && response.statusCode < 400) {
+            if (
+                !error &&
+                response.statusCode >= 200 &&
+                response.statusCode < 400
+            ) {
                 const { document } = new JSDOM(body).window;
                 const prop = 'innerHTML';
 
                 const data = {
                     NAV_SCRIPTS: document.getElementById('scripts')[prop],
                     NAV_STYLES: document.getElementById('styles')[prop],
-                    NAV_HEADING: document.getElementById('header-withmenu')[prop],
-                    NAV_FOOTER: document.getElementById('footer-withmenu')[prop],
-                    NAV_MENU_RESOURCES: document.getElementById('megamenu-resources')[prop]
+                    NAV_HEADING: document.getElementById('header-withmenu')[
+                        prop
+                    ],
+                    NAV_FOOTER: document.getElementById('footer-withmenu')[
+                        prop
+                    ],
+                    NAV_MENU_RESOURCES: document.getElementById(
+                        'megamenu-resources'
+                    )[prop],
                 };
                 resolve(data);
             } else {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -15,24 +15,24 @@ app.engine('html', mustacheExpress());
 app.set('view engine', 'mustache');
 app.set('views', buildPath);
 
-const renderApp = (decoratorFragments) =>
+const renderApp = decoratorFragments =>
     new Promise((resolve, reject) => {
-      app.render('index.html', decoratorFragments, (err, html) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(html);
-        }
-      });
+        app.render('index.html', decoratorFragments, (err, html) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(html);
+            }
+        });
     });
 
-const startServer = (html) => {
+const startServer = html => {
     app.use(basePath('/'), express.static(buildPath, { index: false }));
 
     app.get(basePath('/internal/isAlive'), (req, res) => res.sendStatus(200));
     app.get(basePath('/internal/isReady'), (req, res) => res.sendStatus(200));
 
-    app.get('*', (req, res) => {
+    app.get(basePath('/*'), (req, res) => {
         res.send(html);
     });
 
@@ -42,5 +42,5 @@ const startServer = (html) => {
 };
 
 getDecorator()
-    .then(renderApp, (error) => console.log('Kunne ikke hente dekoratør ', error))
-    .then(startServer, (error) => console.log('Kunne ikke rendre app ', error));
+    .then(renderApp, error => console.log('Kunne ikke hente dekoratør ', error))
+    .then(startServer, error => console.log('Kunne ikke rendre app ', error));

--- a/src/server/sonekrysning.js
+++ b/src/server/sonekrysning.js
@@ -18,8 +18,8 @@ const proxyConfig = {
 
 if (envProperties.APIGW_HEADER) {
     proxyConfig.headers = {
-        'x-nav-apiKey': envProperties.APIGW_HEADER
-    }
+        'x-nav-apiKey': envProperties.APIGW_HEADER,
+    };
 }
 
 module.exports = proxy(proxyConfig);

--- a/src/utils/metricsUtils.ts
+++ b/src/utils/metricsUtils.ts
@@ -1,0 +1,11 @@
+interface Logger {
+    event: (navn: string, fields: {}, tags: {}) => void;
+}
+
+export function log(eventNavn: string, felter?: {}, tags?: {}) {
+    const logger: Logger = (window as any) /*tslint:disable-line:no-any*/
+        .frontendlogger;
+    if (logger) {
+        logger.event(eventNavn, felter || {}, tags || {});
+    }
+}

--- a/src/utils/metricsUtils.ts
+++ b/src/utils/metricsUtils.ts
@@ -1,11 +1,20 @@
 interface Logger {
     event: (navn: string, fields: {}, tags: {}) => void;
+    error: (melding: string) => void;
 }
 
-export function log(eventNavn: string, felter?: {}, tags?: {}) {
+export function logEvent(eventNavn: string, felter?: {}, tags?: {}) {
     const logger: Logger = (window as any) /*tslint:disable-line:no-any*/
         .frontendlogger;
     if (logger) {
         logger.event(eventNavn, felter || {}, tags || {});
+    }
+}
+
+export function logError(melding: string) {
+    const logger: Logger = (window as any) /*tslint:disable-line:no-any*/
+        .frontendlogger;
+    if (logger) {
+        logger.error(melding);
     }
 }

--- a/src/utils/metricsUtils.ts
+++ b/src/utils/metricsUtils.ts
@@ -4,16 +4,14 @@ interface Logger {
 }
 
 export function logEvent(eventNavn: string, felter?: {}, tags?: {}) {
-    const logger: Logger = (window as any) /*tslint:disable-line:no-any*/
-        .frontendlogger;
+    const logger: Logger = (window as any).frontendlogger;
     if (logger) {
         logger.event(eventNavn, felter || {}, tags || {});
     }
 }
 
 export function logError(melding: string) {
-    const logger: Logger = (window as any) /*tslint:disable-line:no-any*/
-        .frontendlogger;
+    const logger: Logger = (window as any).frontendlogger;
     if (logger) {
         logger.error(melding);
     }


### PR DESCRIPTION
PUS har eksponert frontendloggeren til våres domener i SBS.
`https://arbeidsgiver.nav.no/frontendlogger/logger.js` og `https://arbeidsgiver-q.nav.no/frontendlogger/logger.js`.

`logEvent` logger til Grafana.
`logError` logger til Kibana. Kan søkes opp med `x_appname:kontakt-oss`.
Feil som propagerer til `window` blir også automatisk logget til Kibana.