### PR TITLE
Sett opp automatisk deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
-            echo "export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:'%an <%ae>')" >> $BASH_ENV
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
@@ -72,3 +71,5 @@ jobs:
             echo "committet"
             git push git@github.com:navikt/tag-iac.git
             echo "pushet"
+          environment:
+            ORIGINAL_COMMITTER: André Mossige <mossige.a@gmail.com>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,5 +70,5 @@ jobs:
             echo "added"
             git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL"
             echo "committet"
-            git push git@github.com:navikt/kontakt-oss.git
+            git push git@github.com:navikt/tag-iac.git
             echo "pushet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,6 @@ jobs:
             echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
-            echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
-            echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
-            echo 'export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:"%an <%ae>")' >> $BASH_ENV
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
@@ -50,6 +47,7 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker push "$DOCKER_IMAGE_VERSIONED"
             docker push "$DOCKER_IMAGE_UNVERSIONED"
+            echo "Pushet $DOCKER_IMAGE_VERSIONED til dockerhub"
 
   oppdater-preprod-versjon:
     docker:
@@ -65,7 +63,6 @@ jobs:
             echo 'export BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"' >> $BASH_ENV
             echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
-            echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
             echo 'export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:"%an <%ae>")' >> $BASH_ENV
@@ -81,7 +78,7 @@ jobs:
             cd tag-iac
             bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
-            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
+            git commit -m "Bump preprod/$CIRCLE_PROJECT_REPONAME til versjon $DOCKER_IMAGE_VERSIONED" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             git push git@github.com:navikt/tag-iac.git
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,14 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push "$DOCKER_IMAGE_VERSIONED"
           docker push "$DOCKER_IMAGE_UNVERSIONED"
+
+    - add_ssh_keys:
+        fingerprints:
+          - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
+
+    - run:
+        name: Test å pulle privat iac repo
+        command: |
+          git clone git@github.com:navikt/tag-iac.git
+          cd tag-iac
+          ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,7 @@ jobs:
             echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
-            echo 'export GIT_AUTHOR_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
-            echo 'export GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
       - run:
           name: Bygg Docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ jobs:
             echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
+            echo 'GIT_AUTHOR_NAME="team-tag"' >> $BASH_ENV
+            echo 'GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
+            echo 'GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ jobs:
 workflows:
   version: 2
   bygg_og_opppdater_iac_repo:
-    - build
-    - oppdater-preprod-versjon:
-        requires:
-          - build
+    jobs:
+      - build
+      - oppdater-preprod-versjon:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ jobs:
             echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
             echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
-            echo 'GIT_AUTHOR_NAME="team-tag"' >> $BASH_ENV
-            echo 'GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
-            echo 'GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
-            echo 'GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'export GIT_AUTHOR_NAME="team-tag"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
+            echo 'export GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
 
       - run:
           name: Bygg Docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
             echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:"%an <%ae>")' >> $BASH_ENV
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
@@ -69,5 +70,3 @@ jobs:
             echo "committet"
             git push git@github.com:navikt/tag-iac.git
             echo "pushet"
-          environment:
-            ORIGINAL_COMMITTER: André Mossige <mossige.a@gmail.com>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,39 @@ jobs:
             cd tag-iac
             bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
-            git commit -m "Bump preprod/$CIRCLE_PROJECT_REPONAME til versjon $DOCKER_IMAGE_VERSIONED" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
+            git commit -m "Bump preprod/$CIRCLE_PROJECT_REPONAME til v. $BRANCH_PREFIX$RELEASE_VERSION" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
+            git push git@github.com:navikt/tag-iac.git
+
+  oppdater-prod-versjon:
+    docker:
+      - image: circleci/node
+
+    steps:
+      - checkout
+
+      - run:
+          name: Sett miljøvariable
+          command: |
+            echo 'export RELEASE_VERSION="$(git rev-list --count $CIRCLE_SHA1)"' >> $BASH_ENV
+            echo 'export BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"' >> $BASH_ENV
+            echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
+            echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:"%an <%ae>")' >> $BASH_ENV
+
+      - add_ssh_keys:
+          fingerprints:
+            - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
+
+      - run:
+          name: Oppdater prod app versjon i tag-iac
+          command: |
+            git clone git@github.com:navikt/tag-iac.git
+            cd tag-iac
+            bash ./set-image.sh prod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
+            git add prod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+            git commit -m "Bump prod/$CIRCLE_PROJECT_REPONAME til v. $BRANCH_PREFIX$RELEASE_VERSION" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             git push git@github.com:navikt/tag-iac.git
 
 workflows:
@@ -88,3 +120,10 @@ workflows:
       - oppdater-preprod-versjon:
           requires:
             - build
+      - hold:
+          type: approval
+          requires:
+            - build
+      - oppdater-prod-versjon:
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,11 @@ jobs:
           - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
 
     - run:
-        name: Test å pulle privat iac repo
+        name: Oppdater app versjon i tag-iac
         command: |
           git clone git@github.com:navikt/tag-iac.git
           cd tag-iac
-          ls
+          ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
+          git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+          git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$CIRCLE_USERNAME"
+          git push origin master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
-
+            echo 'export ORIGINAL_COMMITTER="$(git log -1 --pretty=format:\'%an <%ae>\')"' >> $BASH_ENV
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
@@ -68,7 +68,7 @@ jobs:
             echo "kjørte script"
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
             echo "added"
-            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL"
+            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             echo "committet"
             git push git@github.com:navikt/tag-iac.git
             echo "pushet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker push "$DOCKER_IMAGE_VERSIONED"
             docker push "$DOCKER_IMAGE_UNVERSIONED"
-            echo "Pushet $DOCKER_IMAGE_VERSIONED til dockerhub"
 
   oppdater-preprod-versjon:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,26 +114,28 @@ jobs:
 
 workflows:
   version: 2
-  bygg:
-    branches:
-      ignore:
-        - master
-    jobs:
-      - build
-
   bygg_og_opppdater_iac_repo:
-    branches:
-      only:
-        - master
     jobs:
       - build
       - oppdater-preprod-versjon:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
       - godkjenn-til-prod:
           type: approval
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
       - oppdater-prod-versjon:
           requires:
             - godkjenn-til-prod
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,5 +59,5 @@ jobs:
             cd tag-iac
             bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
-            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$CIRCLE_USERNAME"
+            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL"
             git push origin master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,31 @@ jobs:
             docker push "$DOCKER_IMAGE_VERSIONED"
             docker push "$DOCKER_IMAGE_UNVERSIONED"
 
+  oppdater-preprod-versjon:
+    docker:
+      - image: circleci/node
+
+    steps:
+      - checkout
+
+      - run:
+          name: Sett miljøvariable
+          command: |
+            echo 'export RELEASE_VERSION="$(git rev-list --count $CIRCLE_SHA1)"' >> $BASH_ENV
+            echo 'export BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"' >> $BASH_ENV
+            echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
+            echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
+            echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
+            echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
+            echo 'export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:"%an <%ae>")' >> $BASH_ENV
+
       - add_ssh_keys:
           fingerprints:
             - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
 
       - run:
-          name: Oppdater app versjon i tag-iac
+          name: Oppdater preprod app versjon i tag-iac
           command: |
             git clone git@github.com:navikt/tag-iac.git
             cd tag-iac
@@ -64,3 +83,11 @@ jobs:
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
             git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             git push git@github.com:navikt/tag-iac.git
+
+workflows:
+  version: 2
+  bygg_og_opppdater_iac_repo:
+    - build
+    - oppdater-preprod-versjon:
+        requires:
+          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             echo 'export GIT_COMMITTER_NAME="team-tag"' >> $BASH_ENV
             echo 'export GIT_AUTHOR_EMAIL="teamtag@nav.no"' >> $BASH_ENV
             echo 'export GIT_COMMITTER_EMAIL="teamtag@nav.no"' >> $BASH_ENV
-            echo 'export ORIGINAL_COMMITTER="$(git log -1 --pretty=format:\'%an <%ae>\')"' >> $BASH_ENV
+            echo "export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:'%an <%ae>')" >> $BASH_ENV
       - run:
           name: Bygg Docker image
           command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,10 @@ workflows:
       - oppdater-preprod-versjon:
           requires:
             - build
-      - hold:
+      - godkjenn-til-prod:
           type: approval
           requires:
             - build
       - oppdater-prod-versjon:
           requires:
-            - hold
+            - godkjenn-til-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,8 @@ jobs:
           name: Oppdater app versjon i tag-iac
           command: |
             git clone git@github.com:navikt/tag-iac.git
-            echo "Klonet"
             cd tag-iac
-            echo "cd"
             bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
-            echo "kjørte script"
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
-            echo "added"
             git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
-            echo "committet"
             git push git@github.com:navikt/tag-iac.git
-            echo "pushet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,14 @@ jobs:
           name: Oppdater app versjon i tag-iac
           command: |
             git clone git@github.com:navikt/tag-iac.git
+            echo "Klonet"
             cd tag-iac
+            echo "cd"
             bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
+            echo "kjørte script"
             git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+            echo "added"
             git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL"
-            git push origin master
+            echo "committet"
+            git push git@github.com:navikt/kontakt-oss.git
+            echo "pushet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,17 @@ jobs:
 
 workflows:
   version: 2
+  bygg:
+    branches:
+      ignore:
+        - master
+    jobs:
+      - build
+
   bygg_og_opppdater_iac_repo:
+    branches:
+      only:
+        - master
     jobs:
       - build
       - oppdater-preprod-versjon:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,8 @@ jobs:
           command: |
             git clone git@github.com:navikt/tag-iac.git
             cd tag-iac
-            bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
-            git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+            bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator-sbs.yaml $DOCKER_IMAGE_VERSIONED
+            git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator-sbs.yaml
             git commit -m "Bump preprod/$CIRCLE_PROJECT_REPONAME til v. $BRANCH_PREFIX$RELEASE_VERSION" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             git push git@github.com:navikt/tag-iac.git
 
@@ -107,8 +107,8 @@ jobs:
           command: |
             git clone git@github.com:navikt/tag-iac.git
             cd tag-iac
-            bash ./set-image.sh prod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
-            git add prod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+            bash ./set-image.sh prod/$CIRCLE_PROJECT_REPONAME/naiserator-sbs.yaml $DOCKER_IMAGE_VERSIONED
+            git add prod/$CIRCLE_PROJECT_REPONAME/naiserator-sbs.yaml
             git commit -m "Bump prod/$CIRCLE_PROJECT_REPONAME til v. $BRANCH_PREFIX$RELEASE_VERSION" -m "Caused by $CIRCLE_BUILD_URL" --author "$ORIGINAL_COMMITTER"
             git push git@github.com:navikt/tag-iac.git
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,62 +2,62 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/node
+      - image: circleci/node
 
     steps:
-    - checkout
+      - checkout
 
-    - restore_cache:
-        name: Hent Yarn cache
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Installer avhengigheter
-        command: |
-          yarn install --frozen-lockfile
-    - save_cache:
-        name: Lagre Yarn cache
-        key: yarn-packages-{{ checksum "yarn.lock" }}
-        paths:
-            - ~/.cache/yarn
-    - run:
-        name: Kjør tester
-        command: |
-          yarn test
-    - run:
-        name: Bygg produksjonsversjon av React app
-        command: |
-          yarn build
+      - restore_cache:
+          name: Hent Yarn cache
+          keys:
+          - yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Installer avhengigheter
+          command: |
+            yarn install --frozen-lockfile
+      - save_cache:
+          name: Lagre Yarn cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+              - ~/.cache/yarn
+      - run:
+          name: Kjør tester
+          command: |
+            yarn test
+      - run:
+          name: Bygg produksjonsversjon av React app
+          command: |
+            yarn build
 
-    - setup_remote_docker
-    - run:
-        name: Sett miljøvariable
-        command: |
-          echo 'export RELEASE_VERSION="$(git rev-list --count $CIRCLE_SHA1)"' >> $BASH_ENV
-          echo 'export BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"' >> $BASH_ENV
-          echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
-          echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
-          echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
-    - run:
-        name: Bygg Docker image
-        command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
-    - run:
-        name: Push Docker image
-        command: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push "$DOCKER_IMAGE_VERSIONED"
-          docker push "$DOCKER_IMAGE_UNVERSIONED"
+      - setup_remote_docker
+      - run:
+          name: Sett miljøvariable
+          command: |
+            echo 'export RELEASE_VERSION="$(git rev-list --count $CIRCLE_SHA1)"' >> $BASH_ENV
+            echo 'export BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"' >> $BASH_ENV
+            echo 'export BRANCH_PREFIX=`[ $BRANCH_NAME == "master" ] && echo "" || echo $BRANCH_NAME\_`' >> $BASH_ENV
+            echo 'export DOCKER_IMAGE_VERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$BRANCH_PREFIX$RELEASE_VERSION"' >> $BASH_ENV
+            echo 'export DOCKER_IMAGE_UNVERSIONED="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
+      - run:
+          name: Bygg Docker image
+          command: docker build -t "$DOCKER_IMAGE_VERSIONED" -t "$DOCKER_IMAGE_UNVERSIONED" .
+      - run:
+          name: Push Docker image
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push "$DOCKER_IMAGE_VERSIONED"
+            docker push "$DOCKER_IMAGE_UNVERSIONED"
 
-    - add_ssh_keys:
-        fingerprints:
-          - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
+      - add_ssh_keys:
+          fingerprints:
+            - "6f:25:8f:4e:e5:95:e1:e4:b7:41:53:2b:68:01:78:59"
 
-    - run:
-        name: Oppdater app versjon i tag-iac
-        command: |
-          git clone git@github.com:navikt/tag-iac.git
-          cd tag-iac
-          ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
-          git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
-          git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$CIRCLE_USERNAME"
-          git push origin master
+      - run:
+          name: Oppdater app versjon i tag-iac
+          command: |
+            git clone git@github.com:navikt/tag-iac.git
+            cd tag-iac
+            bash ./set-image.sh preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml $DOCKER_IMAGE_VERSIONED
+            git add preprod/$CIRCLE_PROJECT_REPONAME/naiserator.yaml
+            git commit -m "Bump $CIRCLE_PROJECT_REPONAME" -m "Caused by $CIRCLE_BUILD_URL" --author "$CIRCLE_USERNAME"
+            git push origin master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode


### PR DESCRIPTION
Alle brancher blir bygd som vanlig.

Master branch blir bygd og tilhørende `nais.yaml` for preprod i [tag-iac repoet](https://github.com/navikt/tag-iac/) blir oppdatert med riktig docker image versjon.
I [CircleCI](https://circleci.com/gh/navikt/kontakt-oss) må man manuelt trykke godkjent for at prod-versjonen av `nais.yaml` skal bli oppdatert i tac-iac repoet.

Mangler å sette opp en Jenkinsserver på innsiden som kan pulle tag-iac repoet regelmessig og deploye alle configene der.