### PR TITLE
Fjern skråstrek fra URL i nais-config

### DIFF
--- a/nais-dev-sbs.yaml
+++ b/nais-dev-sbs.yaml
@@ -12,7 +12,7 @@ spec:
   vault:
     enabled: true
   ingresses:
-    - https://arbeidsgiver-q.nav.no/kontakt-oss/
+    - https://arbeidsgiver-q.nav.no/kontakt-oss
   liveness:
     path: /kontakt-oss/internal/isAlive
     initialDelay: 5

--- a/nais-prod-sbs.yaml
+++ b/nais-prod-sbs.yaml
@@ -12,7 +12,7 @@ spec:
   vault:
     enabled: true
   ingresses:
-    - https://arbeidsgiver.nav.no/kontakt-oss/
+    - https://arbeidsgiver.nav.no/kontakt-oss
   liveness:
     path: /kontakt-oss/internal/isAlive
     initialDelay: 5


### PR DESCRIPTION
* Uten denne kan du nå appen på /kontakt-oss
* Fungerer fordi vi ikke har noen annen app på
  arbeidsgiver.nav.no/kontakt-oss<hvasomhelst>
* NAIS/Big-IP-løsningen matcher tydeligvis på prefix, så
  /kontakt-oss sluker også alt etterpå